### PR TITLE
fix race conditions and silent error swallowing

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -106,10 +106,11 @@ async function insertIntoCollection(collection, document) {
     } catch (e) {
         if (e.message.includes("E11000 duplicate key error")) {
             console.log(
-                `Skippping dup key ${document._id} in collection ${collection}`
+                `Skipping dup key ${document._id} in collection ${collection}`
             );
             return;
         }
+        throw e;
     }
 }
 
@@ -172,8 +173,21 @@ async function parseBlock(
             height: blockNumber,
             timestamp: null,
             author: await getBlockAuthor(apiAt, blockNumber),
-            specversion: apiAt.runtimeVersion.specVersion.toNumber(),
         };
+
+        // Extract timestamp before processing extrinsics concurrently
+        for (const ex of signedBlock.block.extrinsics) {
+            const extrinsic = ex.toHuman();
+            if (
+                extrinsic.method.section === "timestamp" &&
+                extrinsic.method.method === "set"
+            ) {
+                block.timestamp = parseInt(
+                    extrinsic.method.args.now.replaceAll(",", "")
+                );
+                break;
+            }
+        }
 
         // Collect promises for all extrinsics and their events
         const extrinsicPromises = signedBlock.block.extrinsics.map(
@@ -195,12 +209,8 @@ async function parseBlock(
                 if (
                     extrinsic.method.section === "timestamp" &&
                     extrinsic.method.method === "set"
-                ) {
-                    block.timestamp = parseInt(
-                        extrinsic.method.args.now.replaceAll(",", "")
-                    );
+                )
                     skipInsertExtrinsic = true;
-                }
 
                 extrinsic.timestamp = block.timestamp;
                 const events = allRecords
@@ -379,10 +389,11 @@ async function catchUpAndIndexLive(api) {
     await api.rpc.chain.subscribeFinalizedHeads(async (header) => {
         const currentBlockNumber = parseInt(header.number.toString());
         if (firstRun) {
+            firstRun = false;
             console.log("catching up with chain");
-            catchUpWithChain(
+            await catchUpWithChain(
                 api,
-                // some margin of safety, no harm if the blaock were already indexed
+                // some margin of safety, no harm if the block were already indexed
                 // and it could be that it just took them very long and were not yet processed
                 Math.max(
                     lastProcessedBlockNumber - NUM_CONCURRENT_JOBS * 5,
@@ -390,7 +401,6 @@ async function catchUpAndIndexLive(api) {
                 ),
                 currentBlockNumber - 1
             );
-            firstRun = false;
         }
 
         console.log(`Chain is at block: #${currentBlockNumber}`);


### PR DESCRIPTION
- await catchUpWithChain in live mode to prevent concurrent indexing of overlapping block ranges (catchup vs live subscription)
- extract block timestamp before concurrent extrinsic processing to prevent events getting timestamp: null
- re-throw non-dup-key errors from insertIntoCollection instead of silently swallowing them
- remove duplicate specversion field (lowercase) from block document

we had this error:
```
MongoServerError: Executor error during find command :: caused by :: BSONElement: bad type
2|accounting-backend  |     at Connection.onMessage (/home/encointer/accounting-backend/node_modules/mongodb/lib/cmap/connection.js:202:26)
2|accounting-backend  |     at MessageStream.<anonymous> (/home/encointer/accounting-backend/node_modules/mongodb/lib/cmap/connection.js:61:60)
2|accounting-backend  |     at MessageStream.emit (node:events:519:28)
2|accounting-backend  |     at processIncomingData (/home/encointer/accounting-backend/node_modules/mongodb/lib/cmap/message_stream.js:124:16)
2|accounting-backend  |     at MessageStream._write (/home/encointer/accounting-backend/node_modules/mongodb/lib/cmap/message_stream.js:33:9)
2|accounting-backend  |     at writeOrBuffer (node:internal/streams/writable:564:12)
2|accounting-backend  |     at _write (node:internal/streams/writable:493:10)
2|accounting-backend  |     at Writable.write (node:internal/streams/writable:502:10)
2|accounting-backend  |     at TLSSocket.ondata (node:internal/streams/readable:1007:22)
2|accounting-backend  |     at TLSSocket.emit (node:events:519:28) {
2|accounting-backend  |   ok: 0,
2|accounting-backend  |   code: 10320,
2|accounting-backend  |   codeName: 'Location10320',
2|accounting-backend  |   [Symbol(errorLabels)]: Set(0) {}
2|accounting-backend  | }
```

The corrupted document _id is 0x1813739ce560c670b62a30f4f5bb18b7dcfb2a1e61e78f650b1daca7f731a1e4.                                    
                                                                                                                                                 
  Now — this document has corrupted BSON that can't be read. It needs to be deleted. Since I have a read-only user, I can't delete it. Here's the
   summary:                                                                        
                          
  Root cause: One document in encointer-kusama-pindex.blocks has corrupted BSON (invalid 0xf8 type byte at offset 161).                          
                                                                                                                                                 
  Corrupted document _id:                                                                                                                        
                                                                                                                                                 
  0x1813739ce560c670b62a30f4f5bb18b7dcfb2a1e61e78f650b1daca7f731a1e4                                                                             


  Fix: Delete and re-insert the document. Run this with a write-capable user:

  db.blocks.deleteOne({_id: "0x1813739ce560c670b62a30f4f5bb18b7dcfb2a1e61e78f650b1daca7f731a1e4"})

