### PR TITLE
Fix RPC rate limiting and resource exhaustion

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:alpine
 
 WORKDIR /usr/app
 COPY ./ /usr/app
-RUN npm install
+RUN npm install --legacy-peer-deps
 
 ENV NODE_MAX_OLD_SPACE_SIZE=2048
 CMD [ "sh", "-c", "node --max-old-space-size=${NODE_MAX_OLD_SPACE_SIZE} index.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ WORKDIR /usr/app
 COPY ./ /usr/app
 RUN npm install
 
-CMD [ "node", "index.js" ]
+ENV NODE_MAX_OLD_SPACE_SIZE=2048
+CMD [ "sh", "-c", "node --max-old-space-size=${NODE_MAX_OLD_SPACE_SIZE} index.js" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
       DB_URL: mongodb://root:example@mongo:27017/
       DB_USE_SSL: false
       NUM_CONCURRENT_JOBS: 100
+      MAX_RPC_CONCURRENCY: 10
+      BATCH_DELAY_MS: 0
+      NODE_MAX_OLD_SPACE_SIZE: 2048
       DB_NAME: indexer
       RPC_NODE: "wss://rpc.polkadot.io"
       START_BLOCK: 21000000

--- a/lib.js
+++ b/lib.js
@@ -106,10 +106,11 @@ async function insertIntoCollection(collection, document) {
     } catch (e) {
         if (e.message.includes("E11000 duplicate key error")) {
             console.log(
-                `Skippping dup key ${document._id} in collection ${collection}`
+                `Skipping dup key ${document._id} in collection ${collection}`
             );
             return;
         }
+        throw e;
     }
 }
 
@@ -172,8 +173,21 @@ async function parseBlock(
             height: blockNumber,
             timestamp: null,
             author: await getBlockAuthor(apiAt, blockNumber),
-            specversion: apiAt.runtimeVersion.specVersion.toNumber(),
         };
+
+        // Extract timestamp before processing extrinsics concurrently
+        for (const ex of signedBlock.block.extrinsics) {
+            const extrinsic = ex.toHuman();
+            if (
+                extrinsic.method.section === "timestamp" &&
+                extrinsic.method.method === "set"
+            ) {
+                block.timestamp = parseInt(
+                    extrinsic.method.args.now.replaceAll(",", "")
+                );
+                break;
+            }
+        }
 
         // Collect promises for all extrinsics and their events
         const extrinsicPromises = signedBlock.block.extrinsics.map(
@@ -195,12 +209,8 @@ async function parseBlock(
                 if (
                     extrinsic.method.section === "timestamp" &&
                     extrinsic.method.method === "set"
-                ) {
-                    block.timestamp = parseInt(
-                        extrinsic.method.args.now.replaceAll(",", "")
-                    );
+                )
                     skipInsertExtrinsic = true;
-                }
 
                 extrinsic.timestamp = block.timestamp;
                 const events = allRecords
@@ -379,10 +389,11 @@ async function catchUpAndIndexLive(api) {
     await api.rpc.chain.subscribeFinalizedHeads(async (header) => {
         const currentBlockNumber = parseInt(header.number.toString());
         if (firstRun) {
+            firstRun = false;
             console.log("catching up with chain");
-            catchUpWithChain(
+            await catchUpWithChain(
                 api,
-                // some margin of safety, no harm if the blaock were already indexed
+                // some margin of safety, no harm if the block were already indexed
                 // and it could be that it just took them very long and were not yet processed
                 Math.max(
                     lastProcessedBlockNumber - NUM_CONCURRENT_JOBS * 5,
@@ -390,7 +401,6 @@ async function catchUpAndIndexLive(api) {
                 ),
                 currentBlockNumber - 1
             );
-            firstRun = false;
         }
 
         console.log(`Chain is at block: #${currentBlockNumber}`);

--- a/lib.js
+++ b/lib.js
@@ -1,4 +1,5 @@
 import { ApiPromise, WsProvider } from "@polkadot/api";
+import pLimit from "p-limit";
 
 import { MongoClient } from "mongodb";
 
@@ -24,6 +25,12 @@ export const RPC_NODE = process.env.RPC_NODE;
 
 export const NUM_CONCURRENT_JOBS = parseInt(process.env.NUM_CONCURRENT_JOBS);
 export const START_BLOCK = parseInt(process.env.START_BLOCK || 1);
+const MAX_RPC_CONCURRENCY = parseInt(process.env.MAX_RPC_CONCURRENCY || 10);
+const BATCH_DELAY_MS = parseInt(process.env.BATCH_DELAY_MS || 0);
+const MAX_RETRY_DELAY_MS = 5 * 60 * 1000; // 5 minutes
+const INITIAL_RETRY_DELAY_MS = 5000;
+
+const rpcLimit = pLimit(MAX_RPC_CONCURRENCY);
 
 export async function getLastProcessedBlockNumber() {
     try {
@@ -136,140 +143,186 @@ function mapTypesRecursive(obj) {
 async function parseBlock(
     blockNumber,
     api = null,
-    swallowNonExistingBlocks = false
+    { swallowNonExistingBlocks = false, cachedAuthoredBlocks = null } = {}
 ) {
+    if (!api) {
+        const wsProvider = new WsProvider(RPC_NODE);
+        api = await ApiPromise.create({
+            provider: wsProvider,
+        });
+    }
+
+    let signedBlock;
+    let blockHash;
     try {
-        if (!api) {
-            const wsProvider = new WsProvider(RPC_NODE);
-            api = await ApiPromise.create({
-                provider: wsProvider,
-            });
+        blockHash = await rpcLimit(() =>
+            api.rpc.chain.getBlockHash(blockNumber)
+        );
+        signedBlock = await rpcLimit(() =>
+            api.rpc.chain.getBlock(blockHash)
+        );
+    } catch (e) {
+        if (
+            e.message.includes(
+                "Unable to retrieve header and parent from supplied hash"
+            )
+        ) {
+            console.log(
+                `Block ${blockNumber} is not yet avaiable, skipping.`
+            );
+            if (swallowNonExistingBlocks) return;
+            throw e;
         }
+        throw e;
+    }
 
-        let signedBlock;
-        let blockHash;
-        try {
-            blockHash = await api.rpc.chain.getBlockHash(blockNumber);
-            signedBlock = await api.rpc.chain.getBlock(blockHash);
-        } catch (e) {
-            if (
-                e.message.includes(
-                    "Unable to retrieve header and parent from supplied hash"
-                )
-            ) {
-                console.log(
-                    `Block ${blockNumber} is not yet avaiable, skipping.`
+    const apiAt = await rpcLimit(() =>
+        api.at(signedBlock.block.header.hash)
+    );
+    const allRecords = await rpcLimit(() =>
+        apiAt.query.system.events()
+    );
+
+    const author = cachedAuthoredBlocks
+        ? findAuthorFromCache(cachedAuthoredBlocks, blockNumber)
+        : await getBlockAuthor(apiAt, blockNumber);
+
+    const block = {
+        _id: blockHash.toHuman(),
+        height: blockNumber,
+        timestamp: null,
+        author,
+    };
+
+    // Extract timestamp before processing extrinsics concurrently
+    for (const ex of signedBlock.block.extrinsics) {
+        const extrinsic = ex.toHuman();
+        if (
+            extrinsic.method.section === "timestamp" &&
+            extrinsic.method.method === "set"
+        ) {
+            block.timestamp = parseInt(
+                extrinsic.method.args.now.replaceAll(",", "")
+            );
+            break;
+        }
+    }
+
+    // Collect promises for all extrinsics and their events
+    const extrinsicPromises = signedBlock.block.extrinsics.map(
+        async (ex, extrinsicIndex) => {
+            let skipInsertExtrinsic = false;
+            let extrinsic = ex.toHuman();
+            extrinsic.success = false;
+            extrinsic.blockNumber = blockNumber;
+            extrinsic.blockHash = blockHash.toHuman();
+            extrinsic._id = `${blockNumber}-${extrinsicIndex}`;
+
+            Object.keys(extrinsic.method.args).forEach(function (key) {
+                extrinsic.method.args[key] = mapTypes(
+                    extrinsic.method.args[key]
                 );
-                if (swallowNonExistingBlocks) return;
-                throw e;
-            }
-        }
-
-        const apiAt = await api.at(signedBlock.block.header.hash);
-        const allRecords = await apiAt.query.system.events();
-
-        const block = {
-            _id: blockHash.toHuman(),
-            height: blockNumber,
-            timestamp: null,
-            author: await getBlockAuthor(apiAt, blockNumber),
-        };
-
-        // Extract timestamp before processing extrinsics concurrently
-        for (const ex of signedBlock.block.extrinsics) {
-            const extrinsic = ex.toHuman();
+            });
+            if (["setValidationData"].includes(extrinsic.method.method))
+                skipInsertExtrinsic = true;
             if (
                 extrinsic.method.section === "timestamp" &&
                 extrinsic.method.method === "set"
-            ) {
-                block.timestamp = parseInt(
-                    extrinsic.method.args.now.replaceAll(",", "")
-                );
-                break;
-            }
-        }
-
-        // Collect promises for all extrinsics and their events
-        const extrinsicPromises = signedBlock.block.extrinsics.map(
-            async (ex, extrinsicIndex) => {
-                let skipInsertExtrinsic = false;
-                let extrinsic = ex.toHuman();
-                extrinsic.success = false;
-                extrinsic.blockNumber = blockNumber;
-                extrinsic.blockHash = blockHash.toHuman();
-                extrinsic._id = `${blockNumber}-${extrinsicIndex}`;
-
-                Object.keys(extrinsic.method.args).forEach(function (key) {
-                    extrinsic.method.args[key] = mapTypes(
-                        extrinsic.method.args[key]
-                    );
-                });
-                if (["setValidationData"].includes(extrinsic.method.method))
-                    skipInsertExtrinsic = true;
-                if (
-                    extrinsic.method.section === "timestamp" &&
-                    extrinsic.method.method === "set"
-                )
-                    skipInsertExtrinsic = true;
-
-                extrinsic.timestamp = block.timestamp;
-                const events = allRecords
-                    .filter(
-                        ({ phase }) =>
-                            phase.isApplyExtrinsic &&
-                            phase.asApplyExtrinsic.eq(extrinsicIndex)
-                    )
-                    .map((e) => e.toHuman());
-
-                // Prepare event objects
-                events.forEach((e, eventIndex) => {
-                    e.event.blockNumber = blockNumber;
-                    e.event.blockHash = blockHash.toHuman();
-                    e.event._id = `${extrinsic._id}-${eventIndex}`;
-                    e.event.extrinsicId = extrinsic._id;
-                    e.event.timestamp = block.timestamp;
-                    delete e.event.index;
-                });
-
-                // Insert all events for this extrinsic
-                await Promise.all(
-                    events.map(async (e) => {
-                        if (e.event.method === "ExtrinsicSuccess") {
-                            extrinsic.success = true;
-                            return;
-                        }
-                        await insertIntoCollection("events", e.event);
-                    })
-                );
-
-                extrinsic = { ...extrinsic, ...extrinsic.method };
-                if (!skipInsertExtrinsic) {
-                    await insertIntoCollection("extrinsics", extrinsic);
-                }
-            }
-        );
-        await Promise.all(extrinsicPromises);
-        const systemEvents = allRecords
-            .filter(
-                ({ phase }) => phase.isFinalization || phase.isInitialization
             )
-            .map((e) => e.toHuman());
+                skipInsertExtrinsic = true;
 
-        // Insert all system events
-        await Promise.all(
-            systemEvents.map(async (e, eventIndex) => {
+            extrinsic.timestamp = block.timestamp;
+            const events = allRecords
+                .filter(
+                    ({ phase }) =>
+                        phase.isApplyExtrinsic &&
+                        phase.asApplyExtrinsic.eq(extrinsicIndex)
+                )
+                .map((e) => e.toHuman());
+
+            // Prepare event objects
+            events.forEach((e, eventIndex) => {
                 e.event.blockNumber = blockNumber;
                 e.event.blockHash = blockHash.toHuman();
-                e.event._id = `${blockNumber}-${eventIndex}`;
-                e.event.extrinsicId = null;
+                e.event._id = `${extrinsic._id}-${eventIndex}`;
+                e.event.extrinsicId = extrinsic._id;
                 e.event.timestamp = block.timestamp;
                 delete e.event.index;
-                await insertIntoCollection("events", e.event);
-            })
+            });
+
+            // Insert all events for this extrinsic
+            await Promise.all(
+                events.map(async (e) => {
+                    if (e.event.method === "ExtrinsicSuccess") {
+                        extrinsic.success = true;
+                        return;
+                    }
+                    await insertIntoCollection("events", e.event);
+                })
+            );
+
+            extrinsic = { ...extrinsic, ...extrinsic.method };
+            if (!skipInsertExtrinsic) {
+                await insertIntoCollection("extrinsics", extrinsic);
+            }
+        }
+    );
+    await Promise.all(extrinsicPromises);
+    const systemEvents = allRecords
+        .filter(
+            ({ phase }) => phase.isFinalization || phase.isInitialization
+        )
+        .map((e) => e.toHuman());
+
+    // Insert all system events
+    await Promise.all(
+        systemEvents.map(async (e, eventIndex) => {
+            e.event.blockNumber = blockNumber;
+            e.event.blockHash = blockHash.toHuman();
+            e.event._id = `${blockNumber}-${eventIndex}`;
+            e.event.extrinsicId = null;
+            e.event.timestamp = block.timestamp;
+            delete e.event.index;
+            await insertIntoCollection("events", e.event);
+        })
+    );
+    await insertIntoCollection("blocks", block);
+}
+
+async function processBlocksWithRetry(api, blockNumbers) {
+    let remaining = [...blockNumbers];
+    let delay = INITIAL_RETRY_DELAY_MS;
+
+    // Fetch block authors once for this batch
+    const cachedAuthoredBlocks = await getLastAuthoredBlocks(api);
+
+    while (remaining.length > 0) {
+        const results = await Promise.allSettled(
+            remaining.map((idx) =>
+                parseBlock(idx, api, { cachedAuthoredBlocks })
+            )
         );
-        await insertIntoCollection("blocks", block);
-    } catch (e) {
-        throw e;
+
+        const failed = [];
+        results.forEach((result, i) => {
+            if (result.status === "rejected") {
+                failed.push(remaining[i]);
+                console.log(
+                    `Block ${remaining[i]} failed: ${result.reason?.message || result.reason}`
+                );
+            }
+        });
+
+        if (failed.length === 0) break;
+
+        const jitter = Math.random() * delay * 0.3;
+        const waitMs = Math.min(delay + jitter, MAX_RETRY_DELAY_MS);
+        console.log(
+            `Retrying ${failed.length}/${remaining.length} failed blocks in ${Math.round(waitMs / 1000)}s`
+        );
+        await new Promise((r) => setTimeout(r, waitMs));
+        delay = Math.min(delay * 2, MAX_RETRY_DELAY_MS);
+        remaining = failed;
     }
 }
 
@@ -284,36 +337,31 @@ async function catchUpWithChain(api, blockNumber, endBlockNumber) {
             indexes[indexes.length - 1]
         }`;
         console.time(msg);
-
-        while (true) {
-            try {
-                await Promise.all(indexes.map((idx) => parseBlock(idx, api)));
-                break;
-            } catch (e) {
-                console.log(e);
-                await new Promise((r) => setTimeout(r, 5000));
-                continue;
-            }
-        }
+        await processBlocksWithRetry(api, indexes);
         console.timeEnd(msg);
+
+        if (BATCH_DELAY_MS > 0) {
+            await new Promise((r) => setTimeout(r, BATCH_DELAY_MS));
+        }
     }
 }
 
 export async function findUnprocessedBlockNumbers(blockNumber, endBlockNumber) {
     if (DEBUG) return [];
     const blocks = db.collection("blocks");
-    let processedBlockNumbers = await (
-        await blocks
-            .find({ height: { $gte: blockNumber, $lte: endBlockNumber } })
-            .project({ height: 1, _id: -1 })
-    ).toArray();
-    processedBlockNumbers = processedBlockNumbers.map((e) => e.height);
-    const expectedBlockNumbers = Array(endBlockNumber - blockNumber + 1)
-        .fill()
-        .map((_, idx) => blockNumber + idx);
-    let unprocessedBlockNumbers = expectedBlockNumbers.filter(
-        (e) => !processedBlockNumbers.includes(e)
-    );
+    const cursor = blocks
+        .find({ height: { $gte: blockNumber, $lte: endBlockNumber } })
+        .project({ height: 1, _id: 0 });
+    const processedSet = new Set();
+    for await (const doc of cursor) {
+        processedSet.add(doc.height);
+    }
+    const unprocessedBlockNumbers = [];
+    for (let h = blockNumber; h <= endBlockNumber; h++) {
+        if (!processedSet.has(h)) {
+            unprocessedBlockNumbers.push(h);
+        }
+    }
     return unprocessedBlockNumbers;
 }
 
@@ -328,44 +376,59 @@ export async function parseUnprocessedBlocks(api, blockNumber, endBlockNumber) {
     }
 }
 
-export async function findAllUnprocessedBlockNumbers() {
+export async function findAllUnprocessedBlockNumbers(api, batchCallback) {
     const coll = db.collection("blocks");
 
-    // Include START_BLOCK itself
+    const docCount = await coll.countDocuments({ height: { $gte: START_BLOCK } });
+    if (docCount === 0) {
+        console.log("Empty DB — skipping gap scan, will index sequentially.");
+        return;
+    }
+
     const cursor = coll
         .find(
-            { height: { $gte: START_BLOCK } }, // include START_BLOCK
+            { height: { $gte: START_BLOCK } },
             { projection: { height: 1, _id: 0 } }
         )
         .sort({ height: 1 });
 
-    let prevHeight = START_BLOCK - 1; // so missing START_BLOCK is detected
-    let totalDocs = 0;
-    const missing = [];
-    const outOfRange = [];
-    let maxHeight = -Infinity;
-    let minHeight = Infinity;
+    let prevHeight = START_BLOCK - 1;
+    let missingBatch = [];
+    let totalMissing = 0;
+    const CHUNK_SIZE = NUM_CONCURRENT_JOBS || 100;
 
     for await (const doc of cursor) {
         const h = Number(doc.height);
         if (Number.isNaN(h)) continue;
 
-        totalDocs++;
-        maxHeight = Math.max(maxHeight, h);
-        minHeight = Math.min(minHeight, h);
-
-        if (h < 0) outOfRange.push(h);
-
-        // Detect missing heights starting from START_BLOCK
         if (h > prevHeight + 1) {
             for (let m = prevHeight + 1; m < h; m++) {
-                missing.push(m);
+                missingBatch.push(m);
+                if (missingBatch.length >= CHUNK_SIZE) {
+                    totalMissing += missingBatch.length;
+                    console.log(
+                        `Processing ${missingBatch.length} missing blocks (${totalMissing} total so far)`
+                    );
+                    await batchCallback(api, missingBatch);
+                    missingBatch = [];
+                }
             }
         }
         prevHeight = h;
     }
 
-    return missing;
+    // Process remaining
+    if (missingBatch.length > 0) {
+        totalMissing += missingBatch.length;
+        console.log(
+            `Processing ${missingBatch.length} missing blocks (${totalMissing} total)`
+        );
+        await batchCallback(api, missingBatch);
+    }
+
+    if (totalMissing > 0) {
+        console.log(`Finished reprocessing ${totalMissing} missing blocks.`);
+    }
 }
 
 export async function batchProcessBlocks(api, blockNumbers) {
@@ -373,16 +436,19 @@ export async function batchProcessBlocks(api, blockNumbers) {
         const batchSize = NUM_CONCURRENT_JOBS || 1;
         for (let i = 0; i < blockNumbers.length; i += batchSize) {
             const batch = blockNumbers.slice(i, i + batchSize);
-            const msg = `processing blocks ${batch}`;
+            const msg = `processing blocks ${batch[0]}-${batch[batch.length - 1]}`;
             console.time(msg);
-            await Promise.all(batch.map((idx) => parseBlock(idx, api)));
+            await processBlocksWithRetry(api, batch);
             console.timeEnd(msg);
+
+            if (BATCH_DELAY_MS > 0) {
+                await new Promise((r) => setTimeout(r, BATCH_DELAY_MS));
+            }
         }
     }
 }
 
 async function catchUpAndIndexLive(api) {
-    // last block number from safe base: 5506899
     let lastProcessedBlockNumber = await getLastProcessedBlockNumber();
     let firstRun = true;
     let lastCheckAtHeight = lastProcessedBlockNumber;
@@ -393,8 +459,6 @@ async function catchUpAndIndexLive(api) {
             console.log("catching up with chain");
             await catchUpWithChain(
                 api,
-                // some margin of safety, no harm if the block were already indexed
-                // and it could be that it just took them very long and were not yet processed
                 Math.max(
                     lastProcessedBlockNumber - NUM_CONCURRENT_JOBS * 5,
                     START_BLOCK
@@ -405,26 +469,18 @@ async function catchUpAndIndexLive(api) {
 
         console.log(`Chain is at block: #${currentBlockNumber}`);
 
-        while (true) {
-            try {
-                const start = lastProcessedBlockNumber + 1;
-                const end = currentBlockNumber;
-                if (start <= end) {
-                    const blockNumbers = Array.from(
-                        { length: end - start + 1 },
-                        (_, i) => start + i
-                    );
-                    await batchProcessBlocks(api, blockNumbers);
-                }
-
-                lastProcessedBlockNumber = currentBlockNumber;
-                break;
-            } catch (e) {
-                console.log(e);
-                await new Promise((r) => setTimeout(r, 5000));
-                continue;
-            }
+        const start = lastProcessedBlockNumber + 1;
+        const end = currentBlockNumber;
+        if (start <= end) {
+            const blockNumbers = Array.from(
+                { length: end - start + 1 },
+                (_, i) => start + i
+            );
+            // processBlocksWithRetry handles retries with backoff internally
+            await batchProcessBlocks(api, blockNumbers);
         }
+
+        lastProcessedBlockNumber = currentBlockNumber;
 
         if (currentBlockNumber - lastCheckAtHeight >= 10) {
             await parseUnprocessedBlocks(
@@ -451,8 +507,9 @@ async function getLastestFinalizedBlockNumber(api) {
 
 async function getLastAuthoredBlocks(api) {
     try {
-        const lastAuthoredBlocks =
-            await api.query.collatorSelection.lastAuthoredBlock.entries();
+        const lastAuthoredBlocks = await rpcLimit(() =>
+            api.query.collatorSelection.lastAuthoredBlock.entries()
+        );
         return lastAuthoredBlocks.map(([key, value]) => {
             const collator = key.toHuman();
             const blockNumber = value.toNumber();
@@ -463,25 +520,30 @@ async function getLastAuthoredBlocks(api) {
     }
 }
 
-async function getBlockAuthor(api, blockNumber) {
-    const lastAuthoredBlocks = await getLastAuthoredBlocks(api);
-    const authorEntry = lastAuthoredBlocks.find(
+function findAuthorFromCache(cachedAuthoredBlocks, blockNumber) {
+    const authorEntry = cachedAuthoredBlocks.find(
         ([_, authoredBlockNumber]) => authoredBlockNumber === blockNumber
     );
     return authorEntry ? authorEntry[0][0] : null;
 }
 
+async function getBlockAuthor(api, blockNumber) {
+    const lastAuthoredBlocks = await getLastAuthoredBlocks(api);
+    return findAuthorFromCache(lastAuthoredBlocks, blockNumber);
+}
+
 export async function main() {
+    console.log(
+        `Config: NUM_CONCURRENT_JOBS=${NUM_CONCURRENT_JOBS}, MAX_RPC_CONCURRENCY=${MAX_RPC_CONCURRENCY}, BATCH_DELAY_MS=${BATCH_DELAY_MS}`
+    );
+
     const wsProvider = new WsProvider(RPC_NODE);
     const api = await ApiPromise.create({
         provider: wsProvider,
     });
 
     console.log("Finding unprocessed blocks and process...");
-    const unprocessedBlockNumbers = await findAllUnprocessedBlockNumbers();
-    console.log(`Found ${unprocessedBlockNumbers.length} unprocessed blocks.`);
-
-    await batchProcessBlocks(api, unprocessedBlockNumbers);
+    await findAllUnprocessedBlockNumbers(api, batchProcessBlocks);
 
     let lastProcessedBlockNumber = await getLastProcessedBlockNumber();
     let currentBlockNumber = await getLastestFinalizedBlockNumber(api);

--- a/lib.js
+++ b/lib.js
@@ -27,10 +27,25 @@ export const NUM_CONCURRENT_JOBS = parseInt(process.env.NUM_CONCURRENT_JOBS);
 export const START_BLOCK = parseInt(process.env.START_BLOCK || 1);
 const MAX_RPC_CONCURRENCY = parseInt(process.env.MAX_RPC_CONCURRENCY || 10);
 const BATCH_DELAY_MS = parseInt(process.env.BATCH_DELAY_MS || 0);
+const WS_RECONNECT_MS = parseInt(process.env.WS_RECONNECT_MS || 30000);
 const MAX_RETRY_DELAY_MS = 5 * 60 * 1000; // 5 minutes
 const INITIAL_RETRY_DELAY_MS = 5000;
 
 const rpcLimit = pLimit(MAX_RPC_CONCURRENCY);
+
+function waitForConnection(api, timeoutMs = 120000) {
+    if (api.isConnected) return Promise.resolve();
+    return new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => {
+            reject(new Error(`WS reconnect timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+        const unsub = api.on("connected", () => {
+            clearTimeout(timeout);
+            unsub();
+            resolve();
+        });
+    });
+}
 
 export async function getLastProcessedBlockNumber() {
     try {
@@ -146,7 +161,7 @@ async function parseBlock(
     { swallowNonExistingBlocks = false, cachedAuthoredBlocks = null } = {}
 ) {
     if (!api) {
-        const wsProvider = new WsProvider(RPC_NODE);
+        const wsProvider = new WsProvider(RPC_NODE, WS_RECONNECT_MS);
         api = await ApiPromise.create({
             provider: wsProvider,
         });
@@ -321,6 +336,13 @@ async function processBlocksWithRetry(api, blockNumbers) {
             `Retrying ${failed.length}/${remaining.length} failed blocks in ${Math.round(waitMs / 1000)}s`
         );
         await new Promise((r) => setTimeout(r, waitMs));
+
+        if (!api.isConnected) {
+            console.log("WS disconnected, waiting for reconnect...");
+            await waitForConnection(api);
+            console.log("WS reconnected.");
+        }
+
         delay = Math.min(delay * 2, MAX_RETRY_DELAY_MS);
         remaining = failed;
     }
@@ -534,10 +556,10 @@ async function getBlockAuthor(api, blockNumber) {
 
 export async function main() {
     console.log(
-        `Config: NUM_CONCURRENT_JOBS=${NUM_CONCURRENT_JOBS}, MAX_RPC_CONCURRENCY=${MAX_RPC_CONCURRENCY}, BATCH_DELAY_MS=${BATCH_DELAY_MS}`
+        `Config: NUM_CONCURRENT_JOBS=${NUM_CONCURRENT_JOBS}, MAX_RPC_CONCURRENCY=${MAX_RPC_CONCURRENCY}, BATCH_DELAY_MS=${BATCH_DELAY_MS}, WS_RECONNECT_MS=${WS_RECONNECT_MS}`
     );
 
-    const wsProvider = new WsProvider(RPC_NODE);
+    const wsProvider = new WsProvider(RPC_NODE, WS_RECONNECT_MS);
     const api = await ApiPromise.create({
         provider: wsProvider,
     });

--- a/lib.js
+++ b/lib.js
@@ -37,13 +37,15 @@ function waitForConnection(api, timeoutMs = 120000) {
     if (api.isConnected) return Promise.resolve();
     return new Promise((resolve, reject) => {
         const timeout = setTimeout(() => {
+            api.off("connected", onConnected);
             reject(new Error(`WS reconnect timed out after ${timeoutMs}ms`));
         }, timeoutMs);
-        const unsub = api.on("connected", () => {
+        function onConnected() {
             clearTimeout(timeout);
-            unsub();
+            api.off("connected", onConnected);
             resolve();
-        });
+        }
+        api.on("connected", onConnected);
     });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@polkadot/api": "^16.4.8",
         "csv": "^6.3.1",
         "dotenv": "^16.4.5",
-        "mongodb": "^5.0"
+        "mongodb": "^5.0",
+        "p-limit": "^7.3.0"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -990,6 +991,20 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/p-limit": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/propagate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
@@ -1144,6 +1159,17 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@polkadot/api": "^16.4.8",
     "csv": "^6.3.1",
     "dotenv": "^16.4.5",
-    "mongodb": "^5.0"
+    "mongodb": "^5.0",
+    "p-limit": "^7.3.0"
   }
 }


### PR DESCRIPTION
merge first: 
* [ ] #8 
                                                                                                
  ## Summary                                                                                    

  - **RPC concurrency cap**: Added `p-limit` to throttle concurrent RPC calls to                
  `MAX_RPC_CONCURRENCY` (default 10), preventing rate-limit bans regardless of                  
  `NUM_CONCURRENT_JOBS` batch size                                                              
  - **Exponential backoff with jitter**: Replaced fixed 5s retry delay with exponential backoff 
  (5s → 5min cap, 30% jitter), preventing ban deepening on rate-limited nodes                   
  - **Per-block retry**: Switched from `Promise.all` (all-or-nothing) to `Promise.allSettled`,  
  retrying only failed blocks instead of re-sending the entire batch
  - **Cached block author lookups**: `collatorSelection.lastAuthoredBlock.entries()` is now
  fetched once per batch instead of once per block — eliminates N redundant full-storage scans
  per batch
  - **Fixed O(n²) gap detection**: `findUnprocessedBlockNumbers` now uses `Set.has()` instead of
   `Array.includes()` for processed block lookups
  - **Streaming gap reprocessing**: `findAllUnprocessedBlockNumbers` now processes missing
  blocks in chunks instead of accumulating all gaps into one array; skips entirely on empty DB
  (first run)
  - **Inter-batch delay**: New `BATCH_DELAY_MS` env var for configurable pause between batches
  to reduce sustained RPC pressure
  - **Node.js heap limit**: Dockerfile now sets `--max-old-space-size` via
  `NODE_MAX_OLD_SPACE_SIZE` (default 2048MB), preventing OOM/system freeze when running multiple
   chains

  ## New environment variables

  | Variable | Default | Purpose |
  |---|---|---|
  | `MAX_RPC_CONCURRENCY` | `10` | Max in-flight RPC calls at any time |
  | `BATCH_DELAY_MS` | `0` | Pause (ms) between batch rounds |
  | `NODE_MAX_OLD_SPACE_SIZE` | `2048` | Node.js heap limit in MB |

  ## Test plan

  - [ ] Deploy single chain, verify it indexes and catches up without RPC bans
  - [ ] Simulate RPC errors (kill/restart node) — verify exponential backoff logs and recovery
  - [ ] Run 3 chains simultaneously from scratch with heap limits — verify no system freeze
  - [ ] Verify gap detection works correctly on partially-indexed DB

